### PR TITLE
add desktop launcher for ghidra

### DIFF
--- a/snap/gui/ghidra.desktop
+++ b/snap/gui/ghidra.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Ghidra
+Exec=ghidra
+Icon=${SNAP}/ghidra_10.3_PUBLIC/support/ghidra.png
+Type=Application

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,4 +54,14 @@ parts:
     - ca-certificates
     prime:
       - -usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
-
+  generate-launcher-icon:
+    plugin: nil
+    after:
+      - ghidra
+    build-packages:
+      - imagemagick
+    override-stage: |
+      snapcraftctl stage
+      convert ghidra_10.3_PUBLIC/support/ghidra.ico -alpha on -background none -thumbnail 256x256 -flatten ghidra_10.3_PUBLIC/support/ghidra.png
+    prime:
+      - ghidra_10.3_PUBLIC/support/ghidra.png


### PR DESCRIPTION
Tested with 

```
snapcraft
snap install ./ghidra_10.3_amd64.snap  --dangerous
```

![image](https://github.com/dclane-code/ghidra-snap/assets/6654800/b9ea02a5-33ea-49c0-9a76-a1d7c2928101)
